### PR TITLE
MAST refactor: auth.py

### DIFF
--- a/astroquery/mast/auth.py
+++ b/astroquery/mast/auth.py
@@ -34,7 +34,7 @@ class MastAuth(object):
             self.login(token)
 
     
-    def login(self, token=None, store_token=False, reenter_token=False):  # pragma: no cover
+    def login(self, token=None, store_token=False, reenter_token=False):
         """
         Log session into the MAST portal.
 

--- a/astroquery/mast/auth.py
+++ b/astroquery/mast/auth.py
@@ -1,0 +1,123 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+MAST Authentication
+===================
+
+This file contains functionality related to 
+authenticating MAST users.
+"""
+
+import os
+import keyring
+import warnings
+
+from getpass import getpass
+
+from astropy.logger import log
+
+from . import conf
+
+class MastAuth(object):
+    """
+    MAST authentication class, handles MAST authentication token.
+    """
+
+    def __init__(self, session, token=None):
+
+        self.SESSION_INFO_URL = conf.server + "/whoami"
+        self.AUTH_URL = (conf.server.replace("mast", "auth.mast") +
+                         "/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access")
+        
+        self.session = session
+  
+        if token:
+            self.login(token)
+
+    
+    def login(self, token=None, store_token=False, reenter_token=False):  # pragma: no cover
+        """
+        Log session into the MAST portal.
+
+        Parameters
+        ----------
+        token : string, optional
+            Default is None.
+            The token to authenticate the user.
+            This can be generated at
+            https://auth.mast.stsci.edu/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access.
+            If not supplied, it will be prompted for if not in the keyring or set via $MAST_API_TOKEN
+        store_token : bool, optional
+            Default False.
+            If true, MAST token will be stored securely in your keyring.
+        reenter_token :  bool, optional
+            Default False.
+            Asks for the token even if it is already stored in the keyring or $MAST_API_TOKEN environment variable.
+            This is the way to overwrite an already stored password on the keyring.
+        """
+
+        if token is None and "MAST_API_TOKEN" in os.environ:
+            token = os.environ["MAST_API_TOKEN"]
+
+        if token is None:
+            token = keyring.get_password("astroquery:mast.stsci.edu.token", "masttoken")
+
+        if token is None or reenter_token:
+            info_msg = "If you do not have an API token already, visit the following link to create one: "
+            log.info(info_msg + self.AUTH_URL)
+            token = getpass("Enter MAST API Token: ")
+
+        # store token if desired
+        if store_token:
+            keyring.set_password("astroquery:mast.stsci.edu.token", "masttoken", token)
+
+        self.session.headers["Accept"] = "application/json"
+        self.session.cookies["mast_token"] = token
+        info = self.session_info()
+
+        if not info["anon"]:
+            log.info("MAST API token accepted, welcome {}".format(info["attrib"].get("display_name")))
+        else:
+            warn_msg = ("MAST API token invalid!\n"
+                        "To make create a new API token visit to following link: " +
+                        self.AUTH_URL)
+            warnings.warn(warn_msg, AuthenticationWarning)
+
+        return not info["anon"]
+
+    def logout(self):
+        """
+        Log out session.
+        """
+        self.session.cookies.clear_session_cookies()
+
+    def session_info(self, verbose=False):
+        """
+        Returns user info dictionary and optionally prints info to stdout.
+
+        Parameters
+        ----------
+        verbose : bool, optional
+            Default False. Set to True to print output to stdout.
+
+        Returns
+        -------
+        response : dict
+        """
+
+        # get user information
+        self.session.headers["Accept"] = "application/json"
+        response = self.session.request("GET", self.SESSION_INFO_URL)
+
+        info = response.json()
+
+        if verbose:
+            for key, value in info.items():
+                if isinstance(value, dict):
+                    for subkey, subval in value.items():
+                        print("{}.{}: {}".format(key, subkey, subval))
+                else:
+                    print("{}: {}".format(key, value))
+
+        return info
+
+                    

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -293,7 +293,7 @@ class MastClass(QueryWithLogin):
         else:
             self._auth_obj = MastAuth(self._session)
 
-    def _login(self, token=None, store_token=False, reenter_token=False):  # pragma: no cover
+    def _login(self, token=None, store_token=False, reenter_token=False):
         """
         Log into the MAST portal.
 
@@ -573,7 +573,7 @@ class MastClass(QueryWithLogin):
             warnings.warn("Query returned no results.", NoResultsWarning)
         return all_results
 
-    def logout(self):  # pragma: no cover
+    def logout(self):
         """
         Log out of current MAST session.
         """

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -538,9 +538,9 @@ class TestMast(object):
         assert sector_table['camera'][0] == 1
         assert sector_table['ccd'][0] == 3
 
-        # This should always return no results
-        coord = SkyCoord(0, 90, unit="deg")
-        sector_table = mast.Tesscut.get_sectors(coordinates=coord)
+        # This should always return no results 
+        coord = SkyCoord(90, -66.5, unit="deg")
+        sector_table = mast.Tesscut.get_sectors(coordinates=coord, radius=0)
         assert isinstance(sector_table, Table)
         assert len(sector_table) == 0
 


### PR DESCRIPTION
In this PR I moved all of the MAST authentication code into the class `MastAuth`  in `auth.py`. In core `MastClass` now has a new member`_auth_obj` which is a `MastAuth` object that handles the authentication.