### PR TITLE
MAST refactor: cloud.py

### DIFF
--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -129,7 +129,7 @@ class CloudAccess(object):  # pragma:no-cover
             if data_products includes products not found in the cloud.
         """
 
-        return [self.get_uri(product, include_bucket, full_url) for product in data_products]
+        return [self.get_cloud_uri(product, include_bucket, full_url) for product in data_products]
 
     def download_file(self, data_product, local_path, cache=True):
         """
@@ -151,7 +151,7 @@ class CloudAccess(object):  # pragma:no-cover
         bkt = s3.Bucket(self.pubdata_bucket)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            bucket_path = self.get_uri(data_product, False)
+            bucket_path = self.get_cloud_uri(data_product, False)
         if not bucket_path:
             raise Exception("Unable to locate file {}.".format(data_product['productFilename']))
 

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -1,0 +1,191 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Cloud Access
+============
+
+This file contains functionality for accessing MAST holdings in the cloud.
+"""
+
+import os
+import warnings
+import threading
+
+from astropy.logger import log
+from astropy.utils.console import ProgressBarOrSpinner
+
+from ..exceptions import NoResultsWarning
+
+from . import fpl
+
+
+class CloudAccess(object):  # pragma:no-cover
+    """
+    Class encapsulating access to MAST data in the cloud.
+    """
+
+    def __init__(self, provider="AWS", profile=None, verbose=False):
+        """
+        Initialize class te enable downloading public files from S3 
+        instead of STScI servers.
+        Requires the boto3 and botocore libraries to function.
+
+        Parameters
+        ----------
+        provider : str
+            Which cloud data provider to use. Currently only S3 is supported,
+            so at the moment this argument is ignored.
+        profile : str
+            Profile to use to identify yourself to the cloud provider (usually in ~/.aws/config).
+        verbose : bool
+            Default False. Display extra info and warnings if true.
+        """
+
+        import boto3
+        import botocore
+
+        if profile is not None:
+            self.boto3 = boto3.Session(profile_name=profile)
+        else:
+            self.boto3 = boto3
+        self.botocore = botocore
+
+        self.pubdata_bucket = "stpubdata"
+
+        if verbose:
+            log.info("Using the S3 STScI public dataset")
+            log.warning("Your AWS account will be charged for access to the S3 bucket")
+            log.info("See Request Pricing in https://aws.amazon.com/s3/pricing/ for details")
+            log.info("If you have not configured boto3, follow the instructions here: "
+                     "https://boto3.readthedocs.io/en/latest/guide/configuration.html")
+
+    def get_uri(self, data_product, include_bucket=True, full_url=False):
+        """
+        For a given data product, returns the associated cloud URI.
+        If the product is from a mission that does not support cloud access an
+        exception is raised. If the mission is supported but the product
+        cannot be found in the cloud, the returned path is None.
+
+        Parameters
+        ----------
+        data_product : `~astropy.table.Row`
+            Product to be converted into cloud data uri.
+        include_bucket : bool
+            When either to include the cloud bucket prefix in the result or not.
+        full_url : bool
+            Return a HTTP fetchable url instead of a uri.
+
+        Returns
+        -------
+        response : str or None
+            Cloud URI generated from the data product. If the product cannot be
+            found in the cloud, None is returned.
+        """
+
+        s3_client = self.boto3.client('s3')
+
+        paths = fpl.paths(data_product)
+        if paths is None:
+            raise Exception("Unsupported mission {}".format(data_product['obs_collection']))
+
+        for path in paths:
+            try:
+                s3_client.head_object(Bucket=self.pubdata_bucket, Key=path, RequestPayer='requester')
+                if include_bucket:
+                    path = "s3://{}/{}".format(self.pubdata_bucket, path)
+                elif full_url:
+                    path = "http://s3.amazonaws.com/{}/{}".format(self._pubdata_bucket, path)
+                return path
+            except self.botocore.exceptions.ClientError as e:
+                if e.response['Error']['Code'] != "404":
+                    raise
+
+        warnings.warn("Unable to locate file {}.".format(data_product['productFilename']), NoResultsWarning)
+        return None
+
+
+    def get_uri_list(self, data_products, include_bucket=True, full_url=False):
+        """
+        Takes an `~astropy.table.Table` of data products and returns the associated cloud data uris.
+
+        Parameters
+        ----------
+        data_products : `~astropy.table.Table`
+            Table containing products to be converted into cloud data uris.
+        include_bucket : bool
+            When either to include the cloud bucket prefix in the result or not.
+        full_url : bool
+            Return a HTTP fetchable url instead of a uri.
+
+        Returns
+        -------
+        response : list
+            List of URIs generated from the data products, list way contain entries that are None
+            if data_products includes products not found in the cloud.
+        """
+
+        return [self.get_uri(product, include_bucket, full_url) for product in data_products]
+
+    def download_file(self, data_product, local_path, cache=True):
+        """
+        Takes a data product in the form of an  `~astropy.table.Row` and downloads it from the cloud into
+        the given directory.
+
+        Parameters
+        ----------
+        data_product :  `~astropy.table.Row`
+            Product to download.
+        local_path : str
+            Directory in which files will be downloaded.
+        cache : bool
+            Default is True. If file is found on disc it will not be downloaded again.
+        """
+
+        s3 = self.boto3.resource('s3')
+        s3_client = self.boto3.client('s3')
+        bkt = s3.Bucket(self.pubdata_bucket)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            bucket_path = self.get_uri(data_product, False)
+        if not bucket_path:
+            raise Exception("Unable to locate file {}.".format(data_product['productFilename']))
+
+        # Ask the webserver (in this case S3) what the expected content length is and use that.
+        info_lookup = s3_client.head_object(Bucket=self.pubdata_bucket, Key=bucket_path, RequestPayer='requester')
+        length = info_lookup["ContentLength"]
+        
+        if cache and os.path.exists(local_path):
+            if length is not None:
+                statinfo = os.stat(local_path)
+                if statinfo.st_size != length:
+                    log.warning("Found cached file {0} with size {1} that is "
+                                "different from expected size {2}"
+                                .format(local_path,
+                                        statinfo.st_size,
+                                        length))
+                else:
+                    log.info("Found cached file {0} with expected size {1}."
+                             .format(local_path, statinfo.st_size))
+                    return
+  
+        with ProgressBarOrSpinner(length, ('Downloading URL s3://{0}/{1} to {2} ...'.format(
+                self.pubdata_bucket, bucket_path, local_path))) as pb:
+
+            # Bytes read tracks how much data has been received so far
+            # This variable will be updated in multiple threads below
+            global bytes_read
+            bytes_read = 0
+
+            progress_lock = threading.Lock()
+
+            def progress_callback(numbytes):
+                # Boto3 calls this from multiple threads pulling the data from S3
+                global bytes_read
+
+                # This callback can be called in multiple threads
+                # Access to updating the console needs to be locked
+                with progress_lock:
+                    bytes_read += numbytes
+                    pb.update(bytes_read)
+
+            bkt.download_file(bucket_path, local_path, ExtraArgs={"RequestPayer": "requester"},
+                              Callback=progress_callback)

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -25,14 +25,14 @@ class CloudAccess(object):  # pragma:no-cover
 
     def __init__(self, provider="AWS", profile=None, verbose=False):
         """
-        Initialize class te enable downloading public files from S3 
+        Initialize class to enable downloading public files from S3 
         instead of STScI servers.
         Requires the boto3 and botocore libraries to function.
 
         Parameters
         ----------
         provider : str
-            Which cloud data provider to use. Currently only S3 is supported,
+            Which cloud data provider to use. Currently only AWS S3 is supported,
             so at the moment this argument is ignored.
         profile : str
             Profile to use to identify yourself to the cloud provider (usually in ~/.aws/config).
@@ -58,7 +58,7 @@ class CloudAccess(object):  # pragma:no-cover
             log.info("If you have not configured boto3, follow the instructions here: "
                      "https://boto3.readthedocs.io/en/latest/guide/configuration.html")
 
-    def get_uri(self, data_product, include_bucket=True, full_url=False):
+    def get_cloud_uri(self, data_product, include_bucket=True, full_url=False):
         """
         For a given data product, returns the associated cloud URI.
         If the product is from a mission that does not support cloud access an
@@ -70,9 +70,12 @@ class CloudAccess(object):  # pragma:no-cover
         data_product : `~astropy.table.Row`
             Product to be converted into cloud data uri.
         include_bucket : bool
-            When either to include the cloud bucket prefix in the result or not.
+            Default True. When false returns the path of the file relative to the 
+            top level cloud storage location. 
+            Must be set to False when using the full_url argument.
         full_url : bool
-            Return a HTTP fetchable url instead of a uri.
+            Default False. Return an HTTP fetchable url instead of a cloud uri. 
+            Must set include_bucket to False to use this option.
 
         Returns
         -------
@@ -103,7 +106,7 @@ class CloudAccess(object):  # pragma:no-cover
         return None
 
 
-    def get_uri_list(self, data_products, include_bucket=True, full_url=False):
+    def get_cloud_uri_list(self, data_products, include_bucket=True, full_url=False):
         """
         Takes an `~astropy.table.Table` of data products and returns the associated cloud data uris.
 
@@ -112,9 +115,12 @@ class CloudAccess(object):  # pragma:no-cover
         data_products : `~astropy.table.Table`
             Table containing products to be converted into cloud data uris.
         include_bucket : bool
-            When either to include the cloud bucket prefix in the result or not.
+            Default True. When false returns the path of the file relative to the 
+            top level cloud storage location. 
+            Must be set to False when using the full_url argument.
         full_url : bool
-            Return a HTTP fetchable url instead of a uri.
+            Default False. Return an HTTP fetchable url instead of a cloud uri. 
+            Must set include_bucket to False to use this option.
 
         Returns
         -------
@@ -135,7 +141,7 @@ class CloudAccess(object):  # pragma:no-cover
         data_product :  `~astropy.table.Row`
             Product to download.
         local_path : str
-            Directory in which files will be downloaded.
+            The local filename to which toe downloaded file will be saved.
         cache : bool
             Default is True. If file is found on disc it will not be downloaded again.
         """

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -314,7 +314,6 @@ class MastClass(QueryWithLogin):
         """
 
         return self._auth_obj.login(token, store_token, reenter_token)
-        
 
     @deprecated(since="v0.3.9", message=("The get_token function is deprecated, "
                                          "session token is now the token used for login."))
@@ -1545,9 +1544,12 @@ class ObservationsClass(MastClass):
         data_products : `~astropy.table.Table`
             Table containing products to be converted into cloud data uris.
         include_bucket : bool
-            When either to include the cloud bucket prefix in the result or not.
+            Default True. When false returns the path of the file relative to the 
+            top level cloud storage location. 
+            Must be set to False when using the full_url argument.
         full_url : bool
-            Return a HTTP fetchable url instead of a uri.
+            Default False. Return an HTTP fetchable url instead of a cloud uri. 
+            Must set include_bucket to False to use this option.
 
         Returns
         -------
@@ -1559,7 +1561,7 @@ class ObservationsClass(MastClass):
         if self._cloud_connection is None:
             raise AttributeError("Must enable s3 dataset before attempting to query the s3 information")
 
-        return self._cloud_connection.get_uri_list(data_products, include_bucket, full_url)
+        return self._cloud_connection.get_cloud_uri_list(data_products, include_bucket, full_url)
 
     @deprecated(since="v0.3.9", alternative="get_cloud_uri")
     def get_hst_s3_uri(self, data_product, include_bucket=True, full_url=False):
@@ -1577,9 +1579,12 @@ class ObservationsClass(MastClass):
         data_product : `~astropy.table.Row`
             Product to be converted into cloud data uri.
         include_bucket : bool
-            When either to include the cloud bucket prefix in the result or not.
+            Default True. When false returns the path of the file relative to the 
+            top level cloud storage location. 
+            Must be set to False when using the full_url argument.
         full_url : bool
-            Return a HTTP fetchable url instead of a uri.
+            Default False. Return an HTTP fetchable url instead of a cloud uri. 
+            Must set include_bucket to False to use this option.
 
         Returns
         -------
@@ -1591,7 +1596,7 @@ class ObservationsClass(MastClass):
         if self._cloud_connection is None:
             raise AttributeError("Must enable s3 dataset before attempting to query the s3 information")
 
-        return self._cloud_connection.get_uri(data_product, include_bucket, full_url)
+        return self._cloud_connection.get_cloud_uri(data_product, include_bucket, full_url)
 
     def _download_files(self, products, base_dir, cache=True, cloud_only=False,):
         """


### PR DESCRIPTION
In this PR I moved all of the MAST cloud access code into the class `CloudAccess` in `cloud.py`. In core ObservationsClass now has the  member `_cloud_connection` instead of `_boto3`, `_botocore`, and `_pubdata_bucket`. 