### PR TITLE
discovery_portal.py

### DIFF
--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -37,10 +37,11 @@ conf = Conf()
 from .core import Observations, ObservationsClass, Catalogs, CatalogsClass
 from .tesscut import TesscutClass, Tesscut
 from .discovery_portal import MastClass, Mast
+from . import utils
 
 __all__ = ['Observations', 'ObservationsClass',
            'Catalogs', 'CatalogsClass',
            'Mast', 'MastClass',
            'Tesscut', 'TesscutClass',
-           'Conf', 'conf'
+           'Conf', 'conf', 'utils'
            ]

--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -34,12 +34,13 @@ class Conf(_config.ConfigNamespace):
 conf = Conf()
 
 
-from .core import Observations, ObservationsClass, Catalogs, CatalogsClass, Mast, MastClass
+from .core import Observations, ObservationsClass, Catalogs, CatalogsClass
 from .tesscut import TesscutClass, Tesscut
+from .discovery_portal import MastClass, Mast
 
 __all__ = ['Observations', 'ObservationsClass',
            'Catalogs', 'CatalogsClass',
            'Mast', 'MastClass',
            'Tesscut', 'TesscutClass',
-           'Conf', 'conf',
+           'Conf', 'conf'
            ]

--- a/astroquery/mast/auth.py
+++ b/astroquery/mast/auth.py
@@ -15,6 +15,8 @@ from getpass import getpass
 
 from astropy.logger import log
 
+from ..exceptions import AuthenticationWarning
+
 from . import conf
 
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -42,8 +42,7 @@ from .auth import MastAuth
 from .cloud import CloudAccess
 
 
-__all__ = ['Observations', 'ObservationsClass',
-           'Mast', 'MastClass']
+__all__ = ['Observations', 'ObservationsClass']
 
 
 def _prepare_service_request_string(json_obj):
@@ -255,7 +254,7 @@ def _fabric_json_to_table(json_obj):
 
 
 @async_to_sync
-class MastClass(QueryWithLogin):
+class MastClass_old(QueryWithLogin):
     """
     MAST query class.
 
@@ -265,7 +264,7 @@ class MastClass(QueryWithLogin):
 
     def __init__(self, mast_token=None):
 
-        super(MastClass, self).__init__()
+        super(MastClass_old, self).__init__()
 
         self._MAST_REQUEST_URL = conf.server + "/api/v0/invoke"
         self._COLUMNS_CONFIG_URL = conf.server + "/portal/Mashup/Mashup.asmx/columnsconfig"
@@ -386,7 +385,7 @@ class MastClass(QueryWithLogin):
 
         start_time = time.time()
 
-        response = super(MastClass, self)._request(method, url, params=params, data=data, headers=headers,
+        response = super(MastClass_old, self)._request(method, url, params=params, data=data, headers=headers,
                                                    files=files, cache=cache, stream=stream, auth=auth)
         if (time.time() - start_time) >= self.TIMEOUT:
             raise TimeoutError("Timeout limit of {} exceeded.".format(self.TIMEOUT))
@@ -440,7 +439,7 @@ class MastClass(QueryWithLogin):
             status = "EXECUTING"
 
             while status == "EXECUTING":
-                response = super(MastClass, self)._request(method, url, params=params, data=data,
+                response = super(MastClass_old, self)._request(method, url, params=params, data=data,
                                                            headers=headers, files=files, cache=False,
                                                            stream=stream, auth=auth)
 
@@ -989,7 +988,7 @@ class MastClass(QueryWithLogin):
 
 
 @async_to_sync
-class ObservationsClass(MastClass):
+class ObservationsClass(MastClass_old):
     """
     MAST Observations query class.
 
@@ -1744,7 +1743,7 @@ class ObservationsClass(MastClass):
 
 
 @async_to_sync
-class CatalogsClass(MastClass):
+class CatalogsClass(MastClass_old):
     """
     MAST catalog query class.
 
@@ -2216,4 +2215,4 @@ class CatalogsClass(MastClass):
 
 Observations = ObservationsClass()
 Catalogs = CatalogsClass()
-Mast = MastClass()
+#Mast = MastClass()

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -115,9 +115,11 @@ class PortalAPI(BaseQuery):
     """
 
     
-    def __init__(self):
+    def __init__(self, session=None):
         
         super(PortalAPI, self).__init__()
+        if session:
+            self._session = session
 
         self._MAST_REQUEST_URL = conf.server + "/api/v0/invoke"
         self._COLUMNS_CONFIG_URL = conf.server + "/portal/Mashup/Mashup.asmx/columnsconfig"
@@ -546,8 +548,8 @@ class MastClass(QueryWithLogin):
 
          super(MastClass, self).__init__()
 
-         self._portal_api_connection = PortalAPI()
-         self._portal_api_connection._session = self._session
+         self._portal_api_connection = PortalAPI(self._session)
+         #self._portal_api_connection._session = self._session
 
          if mast_token:
              self._authenticated = self._auth_obj = MastAuth(self._session, mast_token)
@@ -672,6 +674,22 @@ class MastClass(QueryWithLogin):
         """
 
         return self._portal_api_connection.service_request_async(service, params, pagesize, page, **kwargs)
+
+    def resolve_object(self, objectname):
+        """
+        Resolves an object name to a position on the sky.
+
+        Parameters
+        ----------
+        objectname : str
+            Name of astronomical object to resolve.
+
+        Returns
+        -------
+        response : `~astropy.coordinates.SkyCoord`
+            The sky position of the given object.
+        """
+        return utils.resolve_object(objectname)
 
 
 Mast = MastClass()

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -1,0 +1,677 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Discovery Portal API
+====================
+
+This module contains various methods for querying the MAST Discovery Portal API.
+"""
+
+import warnings
+import uuid
+import json
+import time
+
+import numpy as np
+
+from urllib.parse import quote as urlencode
+
+from astropy.table import Table, vstack, MaskedColumn
+from astropy.utils import deprecated
+
+from ..query import BaseQuery, QueryWithLogin
+from ..utils import async_to_sync
+from ..utils.class_or_instance import class_or_instance
+
+from . import conf, utils
+from .auth import MastAuth
+
+__all__ = ['MastClass', 'Mast']
+
+def _prepare_service_request_string(json_obj):
+    """
+    Takes a mashup JSON request object and turns it into a url-safe string.
+
+    Parameters
+    ----------
+    json_obj : dict
+        A Mashup request JSON object (python dictionary).
+
+    Returns
+    -------
+    response : str
+        URL encoded Mashup Request string.
+    """
+
+    # Append cache breaker
+    if not 'cacheBreaker' in json_obj:
+        json_obj['cacheBreaker'] = str(uuid.uuid4())
+    request_string = json.dumps(json_obj)
+    return 'request={}'.format(urlencode(request_string))
+
+
+def _mashup_json_to_table(json_obj, col_config=None):
+    """
+    Takes a JSON object as returned from a Mashup request and turns it into an `~astropy.table.Table`.
+
+    Parameters
+    ----------
+    json_obj : dict
+        A Mashup response JSON object (python dictionary)
+    col_config : dict, optional
+        Dictionary that defines column properties, e.g. default value.
+
+    Returns
+    -------
+    response : `~astropy.table.Table`
+    """
+
+    data_table = Table(masked=True)
+
+    if not all(x in json_obj.keys() for x in ['fields', 'data']):
+        raise KeyError("Missing required key(s) 'data' and/or 'fields.'")
+
+    for col, atype in [(x['name'], x['type']) for x in json_obj['fields']]:
+
+        # Removing "_selected_" column
+        if col == "_selected_":
+            continue
+
+        # reading the colum config if given
+        ignore_value = None
+        if col_config:
+            col_props = col_config.get(col, {})
+            ignore_value = col_props.get("ignoreValue", None)
+
+        # regularlizing the type
+        reg_type = utils._parse_type(atype)
+        atype = reg_type[1]
+        ignore_value = reg_type[2] if (ignore_value is None) else ignore_value
+
+        # Make the column list (don't assign final type yet or there will be errors)
+        col_data = np.array([x.get(col, ignore_value) for x in json_obj['data']], dtype=object)
+        if ignore_value is not None:
+            col_data[np.where(np.equal(col_data, None))] = ignore_value
+
+        # no consistant way to make the mask because np.equal fails on ''
+        # and array == value fails with None
+        if atype == 'str':
+            col_mask = (col_data == ignore_value)
+        else:
+            col_mask = np.equal(col_data, ignore_value)
+
+        # add the column
+        data_table.add_column(MaskedColumn(col_data.astype(atype), name=col, mask=col_mask))
+
+    return data_table
+
+
+@async_to_sync
+class PortalAPI(BaseQuery):
+    """
+    MAST Discovery Portal API calss.
+
+    Class that allows direct programatic access to the MAST Portal.
+    Should be used to facilitate all Portal API queries.
+    """
+
+    
+    def __init__(self):
+        
+        super(PortalAPI, self).__init__()
+
+        self._MAST_REQUEST_URL = conf.server + "/api/v0/invoke"
+        self._COLUMNS_CONFIG_URL = conf.server + "/portal/Mashup/Mashup.asmx/columnsconfig"
+        self._MAST_DOWNLOAD_URL = conf.server + "/api/v0.1/Download/file"
+        self._MAST_BUNDLE_URL = conf.server + "/api/v0.1/Download/bundle"
+        
+        self.TIMEOUT = conf.timeout
+        self.PAGESIZE = conf.pagesize
+
+        self._column_configs = dict()
+        self._current_service = None
+
+
+    def _request(self, method, url, params=None, data=None, headers=None,
+                 files=None, stream=False, auth=None, retrieve_all=True):
+        """
+        Override of the parent method:
+        A generic HTTP request method, similar to `~requests.Session.request`
+
+        This is a low-level method not generally intended for use by astroquery
+        end-users.
+
+        The main difference in this function is that it takes care of the long
+        polling requirements of the mashup server.
+        Thus the cache parameter of the parent method is hard coded to false
+        (the MAST server does it's own caching, no need to cache locally and it
+        interferes with follow requests after an 'Executing' response was returned.)
+        Also parameters that allow for file download through this method are removed
+
+
+        Parameters
+        ----------
+        method : 'GET' or 'POST'
+        url : str
+        params : None or dict
+        data : None or dict
+        headers : None or dict
+        auth : None or dict
+        files : None or dict
+        stream : bool
+            See `~requests.request`
+        retrieve_all : bool
+            Default True. Retrieve all pages of data or just the one indicated in the params value.
+
+        Returns
+        -------
+        response : `~requests.Response`
+            The response from the server.
+        """
+
+        start_time = time.time()
+        all_responses = []
+        total_pages = 1
+        cur_page = 0
+
+        while cur_page < total_pages:
+            status = "EXECUTING"
+
+            while status == "EXECUTING":
+                response = super(PortalAPI, self)._request(method, url, params=params, data=data,
+                                                           headers=headers, files=files, cache=False,
+                                                           stream=stream, auth=auth)
+
+                if (time.time() - start_time) >= self.TIMEOUT:
+                    raise TimeoutError("Timeout limit of {} exceeded.".format(self.TIMEOUT))
+
+                # Raising error based on HTTP status if necessary
+                response.raise_for_status()
+
+                result = response.json()
+
+                if not result:  # kind of hacky, but col_config service returns nothing if there is an error
+                    status = "ERROR"
+                else:
+                    status = result.get("status")
+
+            all_responses.append(response)
+
+            if (status != "COMPLETE") or (not retrieve_all):
+                break
+
+            paging = result.get("paging")
+            if paging is None:
+                break
+            total_pages = paging['pagesFiltered']
+            cur_page = paging['page']
+
+            data = data.replace("page%22%3A%20"+str(cur_page)+"%2C", "page%22%3A%20"+str(cur_page+1)+"%2C")
+
+        return all_responses
+        
+    def _get_col_config(self, service, fetch_name=None):
+        """
+        Gets the columnsConfig entry for given service and stores it in `self._column_configs`.
+
+        Parameters
+        ----------
+        service : string
+            The service for which the columns config will be fetched.
+        fetch_name : string, optional
+            If the columns-config associated with the service has a different name,
+            use this argument. The default sets it to the same as service.
+        """
+
+        if not fetch_name:
+            fetch_name = service
+
+        headers = {"User-Agent": self._session.headers["User-Agent"],
+                   "Content-type": "application/x-www-form-urlencoded",
+                   "Accept": "text/plain"}
+
+        response = self._request("POST", self._COLUMNS_CONFIG_URL,
+                                 data=("colConfigId="+fetch_name), headers=headers)
+
+        self._column_configs[service] = response[0].json()
+
+        more = False  # for some catalogs this is not enough information
+        if "tess" in fetch_name.lower():
+            all_name = "Mast.Catalogs.All.Tic"
+            more = True
+        elif "dd." in fetch_name.lower():
+            all_name = "Mast.Catalogs.All.DiskDetective"
+            more = True
+
+        if more:
+            mashup_request = {'service': all_name, 'params': {}, 'format': 'extjs'}
+            req_string = _prepare_service_request_string(mashup_request)
+            response = self._request("POST", self._MAST_REQUEST_URL, data=req_string, headers=headers)
+            json_response = response[0].json()
+
+            self._column_configs[service].update(json_response['data']['Tables'][0]
+                                                 ['ExtendedProperties']['discreteHistogram'])
+            self._column_configs[service].update(json_response['data']['Tables'][0]
+                                                 ['ExtendedProperties']['continuousHistogram'])
+            for col, val in self._column_configs[service].items():
+                val.pop('hist', None)  # don't want to save all this unecessary data
+
+
+    def _parse_result(self, responses, verbose=False):
+        """
+        Parse the results of a list of `~requests.Response` objects and returns an `~astropy.table.Table` of results.
+
+        Parameters
+        ----------
+        responses : list of `~requests.Response`
+            List of `~requests.Response` objects.
+        verbose : bool
+            (presently does nothing - there is no output with verbose set to
+            True or False)
+            Default False.  Setting to True provides more extensive output.
+
+        Returns
+        -------
+        response : `~astropy.table.Table`
+        """
+
+        result_list = []
+
+        # loading the columns config
+        col_config = None
+        if self._current_service:
+            col_config = self._column_configs.get(self._current_service)
+            self._current_service = None  # clearing current service
+
+        for resp in responses:
+            result = resp.json()
+
+            # check for error message
+            if result['status'] == "ERROR":
+                raise RemoteServiceError(result.get('msg', "There was an error with your request."))
+
+            result_table = _mashup_json_to_table(result, col_config)
+            result_list.append(result_table)
+
+        all_results = vstack(result_list)
+
+        # Check for no results
+        if not all_results:
+            warnings.warn("Query returned no results.", NoResultsWarning)
+        return all_results
+
+    @class_or_instance
+    def service_request_async(self, service, params, pagesize=None, page=None, **kwargs):
+        """
+        Given a Mashup service and parameters, builds and excecutes a Mashup query.
+        See documentation `here <https://mast.stsci.edu/api/v0/class_mashup_1_1_mashup_request.html>`__
+        for information about how to build a Mashup request.
+
+        Parameters
+        ----------
+        service : str
+            The Mashup service to query.
+        params : dict
+            JSON object containing service parameters.
+        pagesize : int, optional
+            Default None.
+            Can be used to override the default pagesize (set in configs) for this query only.
+            E.g. when using a slow internet connection.
+        page : int, optional
+            Default None.
+            Can be used to override the default behavior of all results being returned to obtain
+            a specific page of results.
+        **kwargs :
+            See MashupRequest properties
+            `here <https://mast.stsci.edu/api/v0/class_mashup_1_1_mashup_request.html>`__
+            for additional keyword arguments.
+
+        Returns
+        -------
+        response : list of `~requests.Response`
+        """
+
+        # setting self._current_service
+        if service not in self._column_configs.keys():
+            fetch_name = kwargs.pop('fetch_name', None)
+            self._get_col_config(service, fetch_name)
+        self._current_service = service
+
+        # setting up pagination
+        if not pagesize:
+            pagesize = self.PAGESIZE
+        if not page:
+            page = 1
+            retrieve_all = True
+        else:
+            retrieve_all = False
+
+        headers = {"User-Agent": self._session.headers["User-Agent"],
+                   "Content-type": "application/x-www-form-urlencoded",
+                   "Accept": "text/plain"}
+
+        mashup_request = {'service': service,
+                         'params': params,
+                         'format': 'json',
+                         'pagesize': pagesize,
+                         'page': page}
+
+        for prop, value in kwargs.items():
+            mashup_request[prop] = value
+
+        req_string = _prepare_service_request_string(mashup_request)
+        response = self._request("POST", self._MAST_REQUEST_URL, data=req_string, headers=headers,
+                                 retrieve_all=retrieve_all)
+
+        return response
+
+    def _build_filter_set(self, column_config_name, service_name=None, **filters):
+        """
+        Takes user input dictionary of filters and returns a filterlist that the Mashup can understand.
+
+        Parameters
+        ----------
+        column_config_name : string
+            The service for which the columns config will be fetched.
+        service_name : string, optional
+            The service that will use the columns config, default is to be the same as column_config_name.
+        **filters :
+            Filters to apply. At least one filter must be supplied.
+            Valid criteria are coordinates, objectname, radius (as in `query_region` and `query_object`),
+            and all observation fields listed `here <https://mast.stsci.edu/api/v0/_c_a_o_mfields.html>`__.
+            The Column Name is the keyword, with the argument being one or more acceptable values for that parameter,
+            except for fields with a float datatype where the argument should be in the form [minVal, maxVal].
+            For example: filters=["FUV","NUV"],proposal_pi="Osten",t_max=[52264.4586,54452.8914]
+
+        Returns
+        -------
+        response : list(dict)
+            The mashup json filter object.
+        """
+
+        if not service_name:
+            service_name = column_config_name
+
+        if not self._column_configs.get(service_name):
+            self._get_col_config(service_name, fetch_name=column_config_name)
+
+        caom_col_config = self._column_configs[service_name]
+
+        mashup_filters = []
+        for colname, value in filters.items():
+
+            # make sure value is a list-like thing
+            if np.isscalar(value,):
+                value = [value]
+
+            # Get the column type and separator
+            col_info = caom_col_config.get(colname)
+            if not col_info:
+                warnings.warn("Filter {} does not exist. This filter will be skipped.".format(colname), InputWarning)
+                continue
+
+            colType = "discrete"
+            if (col_info.get("vot.datatype", col_info.get("type")) in ("double", "float", "numeric")) \
+               or col_info.get("treatNumeric"):
+                colType = "continuous"
+
+            separator = col_info.get("separator")
+            free_text = None
+
+            # validate user input
+            if colType == "continuous":
+                if len(value) < 2:
+                    warning_string = "{} is continuous, ".format(colname) + \
+                                    "and filters based on min and max values.\n" + \
+                                    "Not enough values provided, skipping..."
+                    warnings.warn(warning_string, InputWarning)
+                    continue
+                elif len(value) > 2:
+                    warning_string = "{} is continuous, ".format(colname) + \
+                                    "and filters based on min and max values.\n" + \
+                                    "Too many values provided, the first two will be " + \
+                                    "assumed to be the min and max values."
+                    warnings.warn(warning_string, InputWarning)
+            else:  # coltype is discrete, all values should be represented as strings, even if numerical
+                value = [str(x) for x in value]
+
+                # check for wildcards
+
+                for i, val in enumerate(value):
+                    if ('*' in val) or ('%' in val):
+                        if free_text:  # free_text is already set cannot set again
+                            warning_string = ("Only one wildcarded value may be used per filter, "
+                                             "all others must be exact.\n"
+                                             "Skipping {}...".format(val))
+                            warnings.warn(warning_string, InputWarning)
+                        else:
+                            free_text = val.replace('*', '%')
+                        value.pop(i)
+
+            # craft mashup filter entry
+            entry = {}
+            entry["paramName"] = colname
+            if separator:
+                entry["separator"] = separator
+            if colType == "continuous":
+                entry["values"] = [{"min": value[0], "max":value[1]}]
+            else:
+                entry["values"] = value
+            if free_text:
+                entry["freeText"] = free_text
+
+            mashup_filters.append(entry)
+
+        return mashup_filters
+
+    def _get_columnsconfig_metadata(self, colconf_name):
+        """
+        Given a columns config id make a table of the associated metadata properties.
+
+        Parameters
+        ----------
+        colconf_name : str
+            The columns config idea to find metadata for (ex. Mast.Caom.Cone).
+
+        Returns
+        -------
+        response : `~astropy.table.Table`
+            The metadata table.
+        """
+
+        headers = {"User-Agent": self._session.headers["User-Agent"],
+                   "Content-type": "application/x-www-form-urlencoded",
+                   "Accept": "text/plain"}
+        response = self._request("POST", self._COLUMNS_CONFIG_URL,
+                                 data=("colConfigId={}".format(colconf_name)), headers=headers)
+
+        column_dict = response[0].json()
+
+        meta_fields = ["Column Name", "Column Label", "Data Type", "Units", "Description", "Examples/Valid Values"]
+        names = []
+        labels = []
+        data_types = []
+        field_units = []
+        descriptions = []
+        examples = []
+
+        for colname in column_dict:
+            # skipping the _selected column (gets rmoved in return table)
+            if colname == "_selected_":
+                continue
+
+            field = column_dict[colname]
+
+            # skipping any columns that are removed
+            if field.get("remove", False):
+                continue
+
+            names.append(colname)
+            labels.append(field.get("text", colname))
+
+            # datatype is a little more complicated
+            d_type = utils._parse_type(field.get("type", ""))[0]
+            if not d_type:
+                d_type = utils._parse_type(field.get("vot.datatype", ""))[0]
+            data_types.append(d_type)
+
+            # units
+            units = field.get("unit", "")
+            if not units:
+                units = field.get("vot.unit", "")
+            field_units.append(units)
+
+            descriptions.append(field.get("vot.description", ""))
+            examples.append(field.get("example", ""))
+
+        meta_table = Table(names=meta_fields, data=[names, labels, data_types, field_units, descriptions, examples])
+
+        # Removing any empty columns
+        for colname in meta_table.colnames:
+            if (meta_table[colname] == "").all():
+                meta_table.remove_column(colname)
+
+        return meta_table
+
+
+@async_to_sync
+class MastClass(QueryWithLogin):
+    """
+    MAST query class.
+
+    Class that allows direct programatic access to the MAST Portal,
+    more flexible but less user friendly than `ObservationsClass`.
+    """
+
+    def __init__(self, mast_token=None):
+
+         super(MastClass, self).__init__()
+
+         self._portal_api_connection = PortalAPI()
+         self._portal_api_connection._session = self._session
+
+         if mast_token:
+             self._authenticated = self._auth_obj = MastAuth(self._session, mast_token)
+         else:
+             self._auth_obj = MastAuth(self._session)
+
+    def _login(self, token=None, store_token=False, reenter_token=False):
+        """
+        Log into the MAST portal.
+
+        Parameters
+        ----------
+        token : string, optional
+            Default is None.
+            The token to authenticate the user.
+            This can be generated at
+            https://auth.mast.stsci.edu/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access.
+            If not supplied, it will be prompted for if not in the keyring or set via $MAST_API_TOKEN
+        store_token : bool, optional
+            Default False.
+            If true, MAST token will be stored securely in your keyring.
+        reenter_token :  bool, optional
+            Default False.
+            Asks for the token even if it is already stored in the keyring or $MAST_API_TOKEN environment variable.
+            This is the way to overwrite an already stored password on the keyring.
+        """
+
+        return self._auth_obj.login(token, store_token, reenter_token)
+
+    @deprecated(since="v0.3.9", message=("The get_token function is deprecated, "
+                                         "session token is now the token used for login."))
+    def get_token(self):
+        return None
+
+    def session_info(self, silent=None, verbose=None):
+        """
+        Displays information about current MAST user, and returns user info dictionary.
+
+        Parameters
+        ----------
+        silent :
+            Deprecated. Use verbose instead.
+        verbose : bool, optional
+            Default True. Set to False to suppress output to stdout.
+
+        Returns
+        -------
+        response : dict
+        """
+
+        # Dealing with deprecated argument
+        if (silent is not None) and (verbose is not None):
+            warnings.warn(("Argument 'silent' has been deprecated, "
+                           "will be ignored in favor of 'verbose'"), AstropyDeprecationWarning)
+        elif silent is not None:
+            warnings.warn(("Argument 'silent' has been deprecated, "
+                           "and will be removed in the future. "
+                           " Use 'verbose' instead."), AstropyDeprecationWarning)
+            verbose = not silent
+        elif (silent is None) and (verbose is None):
+            verbose = True
+
+        return self._auth_obj.session_info(verbose)
+    
+    def logout(self):
+        """
+        Log out of current MAST session.
+        """
+        self._auth_obj.logout()
+        self._authenticated = False
+
+
+    def _parse_result(self, responses, verbose=False):
+        """
+        Parse the results of a list of `~requests.Response` objects and returns an `~astropy.table.Table` of results.
+
+        Parameters
+        ----------
+        responses : list of `~requests.Response`
+            List of `~requests.Response` objects.
+        verbose : bool
+            (presently does nothing - there is no output with verbose set to
+            True or False)
+            Default False.  Setting to True provides more extensive output.
+
+        Returns
+        -------
+        response : `~astropy.table.Table`
+        """
+
+        return self._portal_api_connection._parse_result(responses, verbose)
+        
+    @class_or_instance
+    def service_request_async(self, service, params, pagesize=None, page=None, **kwargs):
+        """
+        Given a Mashup service and parameters, builds and excecutes a Mashup query.
+        See documentation `here <https://mast.stsci.edu/api/v0/class_mashup_1_1_mashup_request.html>`__
+        for information about how to build a Mashup request.
+
+        Parameters
+        ----------
+        service : str
+            The Mashup service to query.
+        params : dict
+            JSON object containing service parameters.
+        pagesize : int, optional
+            Default None.
+            Can be used to override the default pagesize (set in configs) for this query only.
+            E.g. when using a slow internet connection.
+        page : int, optional
+            Default None.
+            Can be used to override the default behavior of all results being returned to obtain
+            a specific page of results.
+        **kwargs :
+            See MashupRequest properties
+            `here <https://mast.stsci.edu/api/v0/class_mashup_1_1_mashup_request.html>`__
+            for additional keyword arguments.
+
+        Returns
+        -------
+        response : list of `~requests.Response`
+        """
+
+        return self._portal_api_connection.service_request_async(service, params, pagesize, page, **kwargs)
+
+
+Mast = MastClass()

--- a/astroquery/mast/tesscut.py
+++ b/astroquery/mast/tesscut.py
@@ -31,7 +31,7 @@ from ..utils import commons
 from ..exceptions import NoResultsWarning, InvalidQueryError, RemoteServiceError
 
 from . import conf
-from .core import Mast
+from .utils import resolve_object
 
 __all__ = ["TesscutClass", "Tesscut"]
 
@@ -65,7 +65,7 @@ def _parse_input_location(coordinates=None, objectname=None):
         raise InvalidQueryError("One of objectname and coordinates must be specified.")
 
     if objectname:
-        obj_coord = Mast.resolve_object(objectname)
+        obj_coord = resolve_object(objectname)
 
     if coordinates:
         obj_coord = commons.parse_coordinates(coordinates)

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -20,7 +20,6 @@ from ...exceptions import (InvalidQueryError, InputWarning)
 
 from ... import mast
 
-
 DATA_FILES = {'Mast.Caom.Cone': 'caom.json',
               'Mast.Name.Lookup': 'resolver.json',
               'columnsconfig': 'columnsconfig.json',
@@ -63,9 +62,9 @@ def patch_post(request):
     except AttributeError:  # pytest < 3
         mp = request.getfuncargvalue("monkeypatch")
 
-    mp.setattr(mast.Mast, '_request', post_mockreturn)
-    #mp.setattr(mast.Mast, '_fabric_request', post_mockreturn)
-    #mp.setattr(mast.Mast, '_download_file', download_mockreturn)
+    mp.setattr(mast.utils, 'resolve_object', resolver_mockreturn)
+        
+    #mp.setattr(PortalAPI, '_request', post_mockreturn)
     mp.setattr(mast.Mast._auth_obj, 'session_info', session_info_mockreturn)
 
     mp.setattr(mast.Observations, '_request', post_mockreturn)
@@ -78,7 +77,7 @@ def patch_post(request):
 
     mp.setattr(mast.Tesscut, "_request", tesscut_get_mockreturn)
     mp.setattr(mast.Tesscut, '_download_file', tess_download_mockreturn)
-
+    
     return mp
 
 
@@ -109,6 +108,12 @@ def post_mockreturn(method="POST", url=None, data=None, timeout=10, **kwargs):
 
     # returning as list because this is what the mast _request function does
     return [MockResponse(content)]
+
+
+def resolver_mockreturn(*args, **kwargs):
+    filename = data_path(DATA_FILES["Mast.Name.Lookup"])
+    content = open(filename, 'rb').read()
+    return MockResponse(content)
 
 
 def download_mockreturn(*args, **kwargs):
@@ -159,26 +164,26 @@ def test_list_missions(patch_post):
         assert m in missions
 
 
-def test_mast_service_request_async(patch_post):
-    service = 'Mast.Name.Lookup'
-    params = {'input': "M103",
-              'format': 'json'}
-    responses = mast.Mast.service_request_async(service, params)
+#def test_mast_service_request_async(patch_post):
+#    service = 'Mast.Name.Lookup'
+#    params = {'input': "M103",
+#              'format': 'json'}
+#    responses = mast.Mast.service_request_async(service, params)
 
-    output = responses[0].json()
+#    output = responses[0].json()
 
-    assert isinstance(responses, list)
-    assert output
+#    assert isinstance(responses, list)
+#    assert output
 
 
-def test_mast_service_request(patch_post):
-    service = 'Mast.Caom.Cone'
-    params = {'ra': 23.34086,
-              'dec': 60.658,
-              'radius': 0.2}
-    result = mast.Mast.service_request(service, params)
+#def test_mast_service_request(patch_post):
+#    service = 'Mast.Caom.Cone'
+#    params = {'ra': 23.34086,
+#              'dec': 60.658,
+#              'radius': 0.2}
+#    result = mast.Mast.service_request(service, params)
 
-    assert isinstance(result, Table)
+#    assert isinstance(result, Table)
 
 
 #def test_resolve_object(patch_post):
@@ -554,13 +559,13 @@ def test_tesscut_get_sector(patch_post):
     assert sector_table['ccd'][0] == 3
 
     # Exercising the search by object name
-    sector_table = mast.Tesscut.get_sectors(objectname="M103")
-    assert isinstance(sector_table, Table)
-    assert len(sector_table) == 1
-    assert sector_table['sectorName'][0] == "tess-s0001-1-3"
-    assert sector_table['sector'][0] == 1
-    assert sector_table['camera'][0] == 1
-    assert sector_table['ccd'][0] == 3
+    #sector_table = mast.Tesscut.get_sectors(objectname="M103")
+    #assert isinstance(sector_table, Table)
+    #assert len(sector_table) == 1
+    #assert sector_table['sectorName'][0] == "tess-s0001-1-3"
+    #assert sector_table['sector'][0] == 1
+    #assert sector_table['camera'][0] == 1
+    #assert sector_table['ccd'][0] == 3
 
 
 def test_tesscut_download_cutouts(patch_post, tmpdir):
@@ -583,11 +588,11 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
     assert os.path.isfile(manifest[0]['Local Path'])
 
     # Exercising the search by object name
-    manifest = mast.Tesscut.download_cutouts(objectname="M103", size=5, path=str(tmpdir))
-    assert isinstance(manifest, Table)
-    assert len(manifest) == 1
-    assert manifest["Local Path"][0][-4:] == "fits"
-    assert os.path.isfile(manifest[0]['Local Path'])
+    #manifest = mast.Tesscut.download_cutouts(objectname="M103", size=5, path=str(tmpdir))
+    #assert isinstance(manifest, Table)
+    #assert len(manifest) == 1
+    #assert manifest["Local Path"][0][-4:] == "fits"
+    #assert os.path.isfile(manifest[0]['Local Path'])
 
 
 def test_tesscut_get_cutouts(patch_post, tmpdir):
@@ -599,7 +604,7 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
     assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
     # Exercising the search by object name
-    cutout_hdus_list = mast.Tesscut.get_cutouts(objectname="M103", size=5)
-    assert isinstance(cutout_hdus_list, list)
-    assert len(cutout_hdus_list) == 1
-    assert isinstance(cutout_hdus_list[0], fits.HDUList)
+    #cutout_hdus_list = mast.Tesscut.get_cutouts(objectname="M103", size=5)
+    #assert isinstance(cutout_hdus_list, list)
+    #assert len(cutout_hdus_list) == 1
+    #assert isinstance(cutout_hdus_list[0], fits.HDUList)

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -64,8 +64,8 @@ def patch_post(request):
         mp = request.getfuncargvalue("monkeypatch")
 
     mp.setattr(mast.Mast, '_request', post_mockreturn)
-    mp.setattr(mast.Mast, '_fabric_request', post_mockreturn)
-    mp.setattr(mast.Mast, '_download_file', download_mockreturn)
+    #mp.setattr(mast.Mast, '_fabric_request', post_mockreturn)
+    #mp.setattr(mast.Mast, '_download_file', download_mockreturn)
     mp.setattr(mast.Mast._auth_obj, 'session_info', session_info_mockreturn)
 
     mp.setattr(mast.Observations, '_request', post_mockreturn)
@@ -181,9 +181,9 @@ def test_mast_service_request(patch_post):
     assert isinstance(result, Table)
 
 
-def test_resolve_object(patch_post):
-    m103_loc = mast.Mast.resolve_object("M103")
-    assert m103_loc.separation(SkyCoord("23.34086 60.658", unit='deg')).value == 0
+#def test_resolve_object(patch_post):
+#    m103_loc = mast.Mast.resolve_object("M103")
+#    assert m103_loc.separation(SkyCoord("23.34086 60.658", unit='deg')).value == 0
 
 
 def test_login_logout(patch_post):

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -61,12 +61,12 @@ class TestMast(object):
         assert sessionInfo['ezid'] == 'anonymous'
         assert sessionInfo['token'] is None
 
-    def test_resolve_object(self):
-        m101_loc = mast.Mast.resolve_object("M101")
-        assert round(m101_loc.separation(SkyCoord("210.80227 54.34895", unit='deg')).value, 4) == 0
+    #def test_resolve_object(self):
+    #    m101_loc = mast.Mast.resolve_object("M101")
+    #    assert round(m101_loc.separation(SkyCoord("210.80227 54.34895", unit='deg')).value, 4) == 0
 
-        ticobj_loc = mast.Mast.resolve_object("TIC 141914082")
-        assert round(ticobj_loc.separation(SkyCoord("94.6175354 -72.04484622", unit='deg')).value, 4) == 0
+    #    ticobj_loc = mast.Mast.resolve_object("TIC 141914082")
+    #    assert round(ticobj_loc.separation(SkyCoord("94.6175354 -72.04484622", unit='deg')).value, 4) == 0
 
     ###########################
     # ObservationsClass tests #
@@ -486,13 +486,12 @@ class TestMast(object):
 
         result = mast.Catalogs.query_hsc_matchid(catalogData[0])
         assert isinstance(result, Table)
-        assert len(result) >= 8
         assert (result['MatchID'] == matchid).all()
 
-        result = mast.Catalogs.query_hsc_matchid(matchid)
-        assert isinstance(result, Table)
-        assert len(result) >= 8
-        assert (result['MatchID'] == matchid).all()
+        result2 = mast.Catalogs.query_hsc_matchid(matchid)
+        assert isinstance(result2, Table)
+        assert len(result2) == len(result)
+        assert (result2['MatchID'] == matchid).all()
 
     def test_catalogs_get_hsc_spectra_async(self):
         responses = mast.Catalogs.get_hsc_spectra_async()

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -22,6 +22,17 @@ from ...exceptions import RemoteServiceError
 @remote_data
 class TestMast(object):
 
+    ###############
+    # utils tests #
+    ###############
+
+    def test_resolve_object(self):
+        m101_loc = mast.utils.resolve_object("M101")
+        assert round(m101_loc.separation(SkyCoord("210.80227 54.34895", unit='deg')).value, 4) == 0
+
+        ticobj_loc = mast.utils.resolve_object("TIC 141914082")
+        assert round(ticobj_loc.separation(SkyCoord("94.6175354 -72.04484622", unit='deg')).value, 4) == 0
+
     ###################
     # MastClass tests #
     ###################
@@ -61,12 +72,13 @@ class TestMast(object):
         assert sessionInfo['ezid'] == 'anonymous'
         assert sessionInfo['token'] is None
 
-    #def test_resolve_object(self):
-    #    m101_loc = mast.Mast.resolve_object("M101")
-    #    assert round(m101_loc.separation(SkyCoord("210.80227 54.34895", unit='deg')).value, 4) == 0
+    def test_resolve_object(self):
+        m101_loc = mast.Mast.resolve_object("M101")
+        assert round(m101_loc.separation(SkyCoord("210.80227 54.34895", unit='deg')).value, 4) == 0
 
-    #    ticobj_loc = mast.Mast.resolve_object("TIC 141914082")
-    #    assert round(ticobj_loc.separation(SkyCoord("94.6175354 -72.04484622", unit='deg')).value, 4) == 0
+        ticobj_loc = mast.Mast.resolve_object("TIC 141914082")
+        assert round(ticobj_loc.separation(SkyCoord("94.6175354 -72.04484622", unit='deg')).value, 4) == 0
+
 
     ###########################
     # ObservationsClass tests #

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -1,0 +1,54 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+MAST Utils
+==========
+
+Miscellaneous functions used through the MAST module.
+"""
+
+import numpy as np
+
+
+def _parse_type(dbtype):
+    """
+    Takes a data type as returned by a database call and regularizes it into a
+    triplet of the form (human readable datatype, python datatype, default value).
+
+    Parameters
+    ----------
+    dbtype : str
+        A data type, as returned by a database call (ex. 'char').
+
+    Returns
+    -------
+    response : tuple
+        Regularized type tuple of the form (human readable datatype, python datatype, default value).
+
+    For example:
+
+    _parse_type("short")
+    ('integer', np.int64, -999)
+    """
+
+    dbtype = dbtype.lower()
+
+    return {
+        'char': ('string', str, ""),
+        'string': ('string', str, ""),
+        'datetime': ('string', str, ""),  # TODO: handle datetimes correctly
+        'date': ('string', str, ""),  # TODO: handle datetimes correctly
+
+        'double': ('float', np.float64, np.nan),
+        'float': ('float', np.float64, np.nan),
+        'decimal': ('float', np.float64, np.nan),
+
+        'int': ('integer', np.int64, -999),
+        'short': ('integer', np.int64, -999),
+        'long': ('integer', np.int64, -999),
+        'number': ('integer', np.int64, -999),
+
+        'boolean': ('boolean', bool, None),
+        'binary': ('boolean', bool, None),
+
+        'unsignedbyte': ('byte', np.ubyte, -999)
+    }.get(dbtype, (dbtype, dbtype, dbtype))


### PR DESCRIPTION
In this PR I moved the MAST Portal interactions into the PortalAPI class in discovery_portal.py. I also rewrote MastClass in that same file so that it has a PortalAPI instance as a member rather than being a subclass.

Because I have yet to extricate the fabric API connection code or rewrite the Observations and Catalogs classes, I did not remove the original MastClass from core.py, so this update causes a lot of duplicate code and is not at final product in terms of refactoring, but I wanted to get more eyes on it before I continue with this current design.

The way I have set up MastClass currently is that it is inherits from the Astroquery QueryWithLogin class so that it is instantiated with a session object member, I then instantiate the PortalAPI member and replace its default session object with MastClass's session. This way there is always only one session although there may be many API connections.