### PR TITLE
cutouts.py

### DIFF
--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -20,9 +20,6 @@ class Conf(_config.ConfigNamespace):
     ssoserver = _config.ConfigItem(
         'https://ssoportal.stsci.edu',
         'MAST SSO Portal server.')
-    catalogsserver = _config.ConfigItem(
-        'https://catalogs.mast.stsci.edu',
-        'Name of the MAST Catalogs server.')
     timeout = _config.ConfigItem(
         600,
         'Time limit for requests from the STScI server.')
@@ -33,7 +30,7 @@ class Conf(_config.ConfigNamespace):
 
 conf = Conf()
 
-from .tesscut import TesscutClass, Tesscut
+from .cutouts import TesscutClass, Tesscut
 from .observations import Observations, ObservationsClass, MastClass, Mast
 from .collections import Catalogs, CatalogsClass
 from .core import MastQueryWithLogin

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -245,20 +245,13 @@ class CatalogsClass(MastQueryWithLogin):
         objectname = criteria.pop('objectname', None)
         radius = criteria.pop('radius', 0.2*u.deg)
 
-        if objectname and coordinates:
-            raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
+        if objectname or coordinates:
+            coordinates = utils._parse_input_location(coordinates, objectname)
 
-        if objectname:
-            coordinates = self.resolve_object(objectname)
-
-        if coordinates:
-            # Put coordinates and radius into consitant format
-            coordinates = commons.parse_coordinates(coordinates)
-
-            # if radius is just a number we assume degrees
-            if isinstance(radius, (int, float)):
-                radius = radius * u.deg
-            radius = coord.Angle(radius)
+        # if radius is just a number we assume degrees
+        if isinstance(radius, (int, float)):
+            radius = radius * u.deg
+        radius = coord.Angle(radius)
 
         # build query
         params = {}

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -40,6 +40,10 @@ class CatalogsClass(MastQueryWithLogin):
 
         super().__init__()
 
+        services = {"panstarrs": {"path": "panstarrs/{data_release}/{table}.json",
+                                  "args": {"data_release": "dr2", "table": "mean"}}}
+        self._service_api_connection._set_service_params(services, "catalogs", True)
+
         self.catalog_limit = None
         self._current_connection = None
 
@@ -107,7 +111,7 @@ class CatalogsClass(MastQueryWithLogin):
                   'radius': radius.deg}
 
         # Determine API connection and service name
-        if catalog.lower() in self._service_api_connection._MAST_CATALOGS_SERVICES:
+        if catalog.lower() in self._service_api_connection._SERVICES:
             self._current_connection = self._service_api_connection
             service = catalog
         else:
@@ -265,7 +269,7 @@ class CatalogsClass(MastQueryWithLogin):
 
         # Determine API connection, service name, and build filter set
         filters = None
-        if catalog.lower() in self._service_api_connection._MAST_CATALOGS_SERVICES:
+        if catalog.lower() in self._service_api_connection._SERVICES:
             self._current_connection = self._service_api_connection
             service = catalog
 

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -31,49 +31,48 @@ from ..utils import commons
 from ..exceptions import NoResultsWarning, InvalidQueryError, RemoteServiceError
 
 from . import conf
-from .utils import resolve_object
+from .utils import _parse_input_location
+from .core import MastQueryWithLogin
+
 
 __all__ = ["TesscutClass", "Tesscut"]
 
 
-def _parse_input_location(coordinates=None, objectname=None):
-    """
-    Convenience function to parse user input of coordinates and objectname.
+def _parse_cutout_size(size):
 
-    Parameters
-    ----------
-    coordinates : str or `astropy.coordinates` object, optional
-        The target around which to search. It may be specified as a
-        string or as the appropriate `astropy.coordinates` object.
-        One and only one of coordinates and objectname must be supplied.
-    objectname : str, optional
-        The target around which to search, by name (objectname="M104")
-        or TIC ID (objectname="TIC 141914082").
-        One and only one of coordinates and objectname must be supplied.
+    # Making size into an array [ny, nx]
+    if np.isscalar(size):
+        size = np.repeat(size, 2)
 
-    Returns
-    -------
-    response : `~astropy.coordinates.SkyCoord`
-        The given coordinates, or object's location as an `~astropy.coordinates.SkyCoord` object.
-    """
+    if isinstance(size, u.Quantity):
+        size = np.atleast_1d(size)
+        if len(size) == 1:
+            size = np.repeat(size, 2)
 
-    # Checking for valid input
-    if objectname and coordinates:
-        raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
+    if len(size) > 2:
+        warnings.warn("Too many dimensions in cutout size, only the first two will be used.",
+                      InputWarning)
 
-    if not (objectname or coordinates):
-        raise InvalidQueryError("One of objectname and coordinates must be specified.")
+    # Getting x and y out of the size
+    if np.isscalar(size[0]):
+        x = size[1]
+        y = size[0]
+        units = "px"
+    elif size[0].unit == u.pixel:
+        x = size[1].value
+        y = size[0].value
+        units = "px"
+    elif size[0].unit.physical_type == 'angle':
+        x = size[1].to(u.deg).value
+        y = size[0].to(u.deg).value
+        units = "d"
+    else:
+        raise InvalidQueryError("Cutout size must be in pixels or angular quantity.")
 
-    if objectname:
-        obj_coord = resolve_object(objectname)
-
-    if coordinates:
-        obj_coord = commons.parse_coordinates(coordinates)
-
-    return obj_coord
+    return {"x": x, "y": y, "units": units}
 
 
-class TesscutClass(BaseQuery):
+class TesscutClass(MastQueryWithLogin):
     """
     MAST TESS FFI cutout query class.
 
@@ -82,9 +81,11 @@ class TesscutClass(BaseQuery):
 
     def __init__(self):
 
-        super(TesscutClass, self).__init__()
+        super().__init__()
 
-        self._TESSCUT_URL = conf.server + "/tesscut/api/v0.1/"
+        services = {"sector": {"path":"sector"},
+                    "astrocut": {"path":"astrocut"}}
+        self._service_api_connection._set_service_params(services, "tesscut")
 
     def get_sectors(self, coordinates=None, radius=0.2*u.deg, objectname=None):
         """
@@ -122,12 +123,11 @@ class TesscutClass(BaseQuery):
             radius = radius * u.deg
         radius = Angle(radius)
 
-        sector_request = "ra={}&dec={}&radius={}d".format(coordinates.ra.deg,
-                                                          coordinates.dec.deg,
-                                                          radius.deg)
-        response = self._request("GET", self._TESSCUT_URL+"sector",
-                                 params=sector_request)
+        params = {"ra": coordinates.ra.deg,
+                  "dec": coordinates.dec.deg,
+                  "radius": radius.deg}
 
+        response = self._service_api_connection.service_request_async("sector", params)
         response.raise_for_status()  # Raise any errors
 
         sector_json = response.json()['results']
@@ -189,46 +189,19 @@ class TesscutClass(BaseQuery):
 
         # Get Skycoord object for coordinates/object
         coordinates = _parse_input_location(coordinates, objectname)
-
-        # Making size into an array [ny, nx]
-        if np.isscalar(size):
-            size = np.repeat(size, 2)
-
-        if isinstance(size, u.Quantity):
-            size = np.atleast_1d(size)
-            if len(size) == 1:
-                size = np.repeat(size, 2)
-
-        if len(size) > 2:
-            warnings.warn("Too many dimensions in cutout size, only the first two will be used.",
-                          InputWarning)
-
-        # Getting x and y out of the size
-        if np.isscalar(size[0]):
-            x = size[1]
-            y = size[0]
-            units = "px"
-        elif size[0].unit == u.pixel:
-            x = size[1].value
-            y = size[0].value
-            units = "px"
-        elif size[0].unit.physical_type == 'angle':
-            x = size[1].to(u.deg).value
-            y = size[0].to(u.deg).value
-            units = "d"
-        else:
-            raise InvalidQueryError("Cutout size must be in pixels or angular quantity.")
+        size_dict = _parse_cutout_size(size)
 
         path = os.path.join(path, '')
         astrocut_request = "ra={}&dec={}&y={}&x={}&units={}".format(coordinates.ra.deg,
                                                                     coordinates.dec.deg,
-                                                                    y, x, units)
+                                                                    size_dict["y"],
+                                                                    size_dict["x"],
+                                                                    size_dict["units"])
         if sector:
             astrocut_request += "&sector={}".format(sector)
 
-        astrocut_url = self._TESSCUT_URL + "astrocut?" + astrocut_request
+        astrocut_url = self._service_api_connection._REQUEST_URL + "astrocut?" + astrocut_request
         zipfile_path = "{}tesscut_{}.zip".format(path, time.strftime("%Y%m%d%H%M%S"))
-
         self._download_file(astrocut_url, zipfile_path)
 
         localpath_table = Table(names=["Local Path"], dtype=[str])
@@ -290,43 +263,20 @@ class TesscutClass(BaseQuery):
 
         # Get Skycoord object for coordinates/object
         coordinates = _parse_input_location(coordinates, objectname)
+        
+        param_dict = _parse_cutout_size(size)
+        param_dict["ra"] = coordinates.ra.deg
+        param_dict["dec"] = coordinates.dec.deg
 
-        # Making size into an array [ny, nx]
-        if np.isscalar(size):
-            size = np.repeat(size, 2)
-
-        if isinstance(size, u.Quantity):
-            size = np.atleast_1d(size)
-            if len(size) == 1:
-                size = np.repeat(size, 2)
-
-        if len(size) > 2:
-            warnings.warn("Too many dimensions in cutout size, only the first two will be used.",
-                          InputWarning)
-
-        # Getting x and y out of the size
-        if np.isscalar(size[0]):
-            x = size[1]
-            y = size[0]
-            units = "px"
-        elif size[0].unit == u.pixel:
-            x = size[1].value
-            y = size[0].value
-            units = "px"
-        elif size[0].unit.physical_type == 'angle':
-            x = size[1].to(u.deg).value
-            y = size[0].to(u.deg).value
-            units = "d"
-        else:
-            raise InvalidQueryError("Cutout size must be in pixels or angular quantity.")
-
-        astrocut_request = "ra={}&dec={}&y={}&x={}&units={}".format(coordinates.ra.deg,
-                                                                    coordinates.dec.deg,
-                                                                    y, x, units)
+        #astrocut_request = "ra={}&dec={}&y={}&x={}&units={}".format(coordinates.ra.deg,
+        #                                                            coordinates.dec.deg,
+        #                                                            y, x, units)
         if sector:
-            astrocut_request += "&sector={}".format(sector)
+            #astrocut_request += "&sector={}".format(sector)
+            param_dict["sector"] = sector
 
-        response = self._request("GET", self._TESSCUT_URL+"astrocut", params=astrocut_request)
+        #response = self._request("GET", self._TESSCUT_URL+"astrocut", params=astrocut_request)
+        response = self._service_api_connection.service_request_async("astrocut", param_dict)
         response.raise_for_status()  # Raise any errors
 
         try:

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -39,6 +39,26 @@ __all__ = ["TesscutClass", "Tesscut"]
 
 
 def _parse_cutout_size(size):
+    """
+    Take a user input cutout size and parse it into the regular format
+    [ny,nx] where nx/ny are quantities with units either pixels or degrees.
+
+    Parameters
+    ----------
+    size : int, array-like, `~astropy.units.Quantity`
+        The size of the cutout array. If ``size`` is a scalar number or
+        a scalar `~astropy.units.Quantity`, then a square cutout of ``size``
+        will be created.  If ``size`` has two elements, they should be in
+        ``(ny, nx)`` order.  Scalar numbers in ``size`` are assumed to be in
+        units of pixels. `~astropy.units.Quantity` objects must be in pixel or
+        angular units.
+
+    Returns
+    -------
+    response : array
+        Size array in the form [ny, nx] where nx/ny are quantities with units 
+        either pixels or degrees.
+    """
 
     # Making size into an array [ny, nx]
     if np.isscalar(size):

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -178,6 +178,7 @@ class ObservationsClass(MastQueryWithLogin):
             mashup_filters = self._portal_api_connection._build_filter_set("Mast.Caom.Cone",
                                                                            "Mast.Caom.Filtered.Position",
                                                                            **criteria)
+            coordinates = utils._parse_input_location(coordinates, objectname)
         else:
             mashup_filters = self._portal_api_connection._build_filter_set("Mast.Caom.Cone",
                                                                            "Mast.Caom.Filtered",
@@ -186,16 +187,7 @@ class ObservationsClass(MastQueryWithLogin):
         # handle position info (if any)
         position = None
 
-        if objectname and coordinates:
-            raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
-
-        if objectname:
-            coordinates = utils.resolve_object(objectname)
-
         if coordinates:
-            # Put coordinates and radius into consitant format
-            coordinates = commons.parse_coordinates(coordinates)
-
             # if radius is just a number we assume degrees
             if isinstance(radius, (int, float)):
                 radius = radius * u.deg

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -69,7 +69,7 @@ def patch_post(request):
 
     mp.setattr(mast.Observations, '_download_file', download_mockreturn)
     mp.setattr(mast.Catalogs, '_download_file', download_mockreturn)
-    mp.setattr(mast.Tesscut, "_request", tesscut_get_mockreturn)
+    #mp.setattr(mast.Tesscut, "_request", tesscut_get_mockreturn)
     mp.setattr(mast.Tesscut, '_download_file', tess_download_mockreturn)
 
     return mp
@@ -105,7 +105,13 @@ def post_mockreturn(self, method="POST", url=None, data=None, timeout=10, **kwar
 
 
 def service_mockreturn(self, method="POST", url=None, data=None, timeout=10, **kwargs):
-    filename = data_path(DATA_FILES["panstarrs"])
+    if "panstarrs" in url:
+        filename = data_path(DATA_FILES["panstarrs"])
+    elif "tesscut" in url:
+        if "sector" in url:
+            filename = data_path(DATA_FILES['tess_sector'])
+        else:
+            filename = data_path(DATA_FILES['tess_cutout'])
     content = open(filename, 'rb').read()
     return MockResponse(content)
 

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -14,7 +14,8 @@ from urllib import parse
 import astropy.coordinates as coord
 
 from ..version import version
-from ..exceptions import ResolverError
+from ..exceptions import ResolverError, InvalidQueryError
+from ..utils import commons
 
 from . import conf
 
@@ -110,3 +111,39 @@ def resolve_object(objectname):
     coordinates = coord.SkyCoord(ra, dec, unit="deg")
 
     return coordinates
+
+def _parse_input_location(coordinates=None, objectname=None):
+    """
+    Convenience function to parse user input of coordinates and objectname.
+
+    Parameters
+    ----------
+    coordinates : str or `astropy.coordinates` object, optional
+        The target around which to search. It may be specified as a
+        string or as the appropriate `astropy.coordinates` object.
+        One and only one of coordinates and objectname must be supplied.
+    objectname : str, optional
+        The target around which to search, by name (objectname="M104")
+        or TIC ID (objectname="TIC 141914082").
+        One and only one of coordinates and objectname must be supplied.
+
+    Returns
+    -------
+    response : `~astropy.coordinates.SkyCoord`
+        The given coordinates, or object's location as an `~astropy.coordinates.SkyCoord` object.
+    """
+
+    # Checking for valid input
+    if objectname and coordinates:
+        raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
+
+    if not (objectname or coordinates):
+        raise InvalidQueryError("One of objectname and coordinates must be specified.")
+
+    if objectname:
+        obj_coord = resolve_object(objectname)
+
+    if coordinates:
+        obj_coord = commons.parse_coordinates(coordinates)
+
+    return obj_coord


### PR DESCRIPTION
In this PR:
- Moved Tesscut functionality into cutouts.py (was tesscut.py)
- Made a service initialization function (`_set_service_params`) for `ServiceAPI` and moved the catalog specific parameters into `CatalogsClass`
- Moved tesscut function `_parse_coordinates` into utils and have catalogs and observations use it